### PR TITLE
libev public interface change, gcc10 extern change

### DIFF
--- a/src/xbindjoy.c
+++ b/src/xbindjoy.c
@@ -40,6 +40,9 @@
 // /////////////////////////////////////////////////////////////////////////////
 // variables
 
+int verbose;
+Display* display;
+
 // the file descriptor for our joystick
 int jsfd;
 
@@ -79,7 +82,7 @@ static void timer_callback(EV_P_ ev_timer* w, int revents) {
 	last_time.tv_nsec = cur_time.tv_nsec;
 }
 
-static void sigint_callback(EV_P_ ev_timer* w, int revents) {
+static void sigint_callback(EV_P_ ev_signal* w, int revents) {
 	ev_break(loop, EVBREAK_ALL);
 }
 

--- a/src/xbindjoy.h
+++ b/src/xbindjoy.h
@@ -21,8 +21,9 @@
 
 #include<X11/Xlib.h>
 
-int verbose;
-Display* display;
+extern int verbose;
+extern Display* display;
+
 
 typedef enum {
 	PRESS,


### PR DESCRIPTION
Hello Saul and thank you for creating this!

I'd like to submit the following changes for your consideration:
 - Public variables `display` and `verbose` are now correctly declared to [make gcc10 happy](https://gcc.gnu.org/gcc-10/porting_to.html).
 - Signature of `sigint_callback` is changed to get it to compile against somewhat modern `libev` versions. I couldn't track down exactly when the public interface change, but from the docs it looks like the change was in place in libev 4.22, released in December 2015.

I needed these changes in order to compile the program on my system (current up to date Arch).

P.S I've also put the project on [AUR](https://aur.archlinux.org/packages/xbindjoy-git) with these and additional Arch-specific changes. Feel free to reference it in the project README if you feel like doing so.

Grigory